### PR TITLE
fix: fix commit hook to make merge commit

### DIFF
--- a/scripts/git-hooks/commit-msg
+++ b/scripts/git-hooks/commit-msg
@@ -3,12 +3,16 @@
 # Regex para verificar el formato de Conventional Commits
 conventional_regex="^(feat|fix|docs|style|refactor|test|chore|build|ci|perf|revert|wip)(\(.+\))?: .{1,50}"
 
+# Regex para permitir commits que comiencen con "Merge branch"
+merge_regex="^Merge branch"
+
 # Leer el mensaje del commit
 commit_message=$(cat "$1")
 
-# Validar el mensaje contra el regex
-if ! echo "$commit_message" | grep -Eq "$conventional_regex"; then
-  echo "Error: El mensaje del commit no cumple con el formato de Conventional Commits."
+# Validar el mensaje contra los regex
+if ! echo "$commit_message" | grep -Eq "$conventional_regex" && ! echo "$commit_message" | grep -Eq "$merge_regex"; then
+  echo "Error: El mensaje del commit no cumple con el formato de Conventional Commits ni comienza con 'Merge branch'."
   echo "Formato esperado: tipo(scope?): mensaje (Ejemplo: feat(api): add new endpoint)"
+  echo "O mensajes de merge como: 'Merge branch ...'"
   exit 1  # Salir con error para evitar que se realice el commit
 fi


### PR DESCRIPTION
### Description

The commit hook does not allow make merge branch commits because of the design of the hook. I fix it.

### Additional context

-

## Verification list (the reviewer does it)

Please, mark the appropriate boxes with an 'x':

- [x] It has been verified that the application is running locally.
- [x] It has been verified that the changes are well integrated into the application.
- [x] It has been verified that the changes correspond to those requested in the task.
- [x] It has been verified that the tests are executed and everything passes correctly.